### PR TITLE
Username cannot start with a full stop. it can only contain letters, numbers, and underscores.

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -33,10 +33,9 @@ import { useToast } from "@/components/ui/use-toast";
 import { Loader2Icon } from "lucide-react";
 
 const formSchema = z.object({
-	username: z.string().regex(/^(?!\.)[a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*$/, {
-		message:
-		  "Username can only contain letters, numbers, and underscores. It must be between 3 and 16 characters long, and it cannot start with a full stop.",
-	  }),
+	username: z.string().min(1, {
+		message: "Username cannot be empty",
+	}),
 	password: z.string().min(1, {
 		message: "Password cannot be empty",
 	}),

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -33,10 +33,10 @@ import { useToast } from "@/components/ui/use-toast";
 import { Loader2Icon } from "lucide-react";
 
 const formSchema = z.object({
-	username: z.string().regex(/^[a-zA-Z]{3,16}$/, {
+	username: z.string().regex(/^(?!\.)[a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*$/, {
 		message:
-			"Username cannot contain special characters, numbers or spaces",
-	}),
+		  "Username can only contain letters, numbers, and underscores. It must be between 3 and 16 characters long, and it cannot start with a full stop.",
+	  }),
 	password: z.string().min(1, {
 		message: "Password cannot be empty",
 	}),

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -46,10 +46,10 @@ const formSchema = z.object({
 		.max(16, {
 			message: "Username must be at most 16 characters long",
 		})
-		.regex(/^[a-zA-Z]{3,16}$/, {
+		.regex(/^(?!\.)[a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*$/, {
 			message:
-				"Username cannot contain special characters, numbers or spaces",
-		})
+			  "Username can only contain letters, numbers, and underscores. It must be between 3 and 16 characters long, and it cannot start with a full stop.",
+		  })
 		.refine(
 			async username => {
 				try {


### PR DESCRIPTION
"Username can only contain letters, numbers, and underscores. It must be between 3 and 16 characters long, and it cannot start with a full stop."

Fixes #14 

cannot start with a full stop
<img width="442" alt="Screenshot 2023-10-17 at 3 17 47 PM" src="https://github.com/inclinedadarsh/timeloom/assets/47117397/75cdfd3c-1042-4d64-bb22-a8e7676ceeab">

can only contain letters, numbers, and underscores
<img width="928" alt="Screenshot 2023-10-17 at 3 18 23 PM" src="https://github.com/inclinedadarsh/timeloom/assets/47117397/eb73e19f-50ca-47fc-b1b0-bdf526a35948">
