### PR TITLE
Issue 9 - Light Mode Feature

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -87,8 +87,8 @@
 		--popover: 240 100% 98%;
 		--popover-foreground: 0 0% 0%;
 	  
-		--primary: 0 0% 98%;
-		--primary-foreground: 0 0% 100%;
+		--primary: 0 0% 0%;
+		--primary-foreground: 0 0% 0%;
 	  
 		--primary-custom: 247 92% 60%;
 		--primary-custom-foreground: 0 0% 100%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -77,40 +77,6 @@
 
 		--link: 220 100% 66%;
 	}
-	.light {
-		--background: 240 100% 98%;
-		--foreground: 0 0% 0%;       
-	  
-		--card: 240 100% 98%;
-		--card-foreground: 0 0% 0%;
-	  
-		--popover: 240 100% 98%;
-		--popover-foreground: 0 0% 0%;
-	  
-		--primary: 247 92% 60%;
-		--primary-foreground: 0 0% 0%;
-	  
-		--primary-custom: 247 92% 60%;
-		--primary-custom-foreground: 0 0% 100%;
-	  
-		--secondary: 235 32% 92%;
-		--secondary-foreground: 0 0% 0%;
-	  
-		--muted: 235 32% 92%;
-		--muted-foreground: 240 50% 20%;
-	  
-		--accent: 235 32% 92%;
-		--accent-foreground: 0 0% 0%;
-	  
-		--destructive: 0 62.8% 30.6%;
-		--destructive-foreground: 0 0% 98%;
-	  
-		--border: 240 3.7% 15.9%;
-		--input: 240 3.7% 15.9%;
-		--ring: 240 4.9% 83.9%;
-	  
-		--link: 220 100% 66%;
-	}
 }
 
 @layer base {

--- a/app/globals.css
+++ b/app/globals.css
@@ -78,14 +78,14 @@
 		--link: 220 100% 66%;
 	}
 	.light {
-		--background: 240 100% 100%;  
+		--background: 240 100% 98%;
 		--foreground: 0 0% 0%;       
 	  
-		--card: 240 10% 3.9%;
-		--card-foreground: 0 0% 98%;
+		--card: 240 100% 98%;
+		--card-foreground: 0 0% 0%;
 	  
-		--popover: 240 10% 3.9%;
-		--popover-foreground: 0 0% 98%;
+		--popover: 240 100% 98%;
+		--popover-foreground: 0 0% 0%;
 	  
 		--primary: 0 0% 98%;
 		--primary-foreground: 0 0% 100%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -93,10 +93,10 @@
 		--primary-custom: 247 92% 60%;
 		--primary-custom-foreground: 0 0% 100%;
 	  
-		--secondary: 240 3.7% 15.9%;
-		--secondary-foreground: 0 0% 98%;
+		--secondary: 235 32% 92%;
+		--secondary-foreground: 0 0% 0%;
 	  
-		--muted: 240 3.7% 15.9%;
+		--muted: 235 32% 92%;
 		--muted-foreground: 240 5% 64.9%;
 	  
 		--accent: 240 3.7% 15.9%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -115,7 +115,7 @@
 
 @layer base {
 	:root{
-		@apply dark:dark light;
+		@apply dark:dark;
 	}
 	html {
 		scroll-behavior: smooth;

--- a/app/globals.css
+++ b/app/globals.css
@@ -97,7 +97,7 @@
 		--secondary-foreground: 0 0% 0%;
 	  
 		--muted: 235 32% 92%;
-		--muted-foreground: 240 5% 64.9%;
+		--muted-foreground: 240 5% 5%;
 	  
 		--accent: 240 3.7% 15.9%;
 		--accent-foreground: 0 0% 98%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,10 @@
 		--icon: 217 19% 27%;
 		--radius: 0.5rem;
 		--transparent: rgba(255, 255, 255, 0);
+		--primary-custom: 247 92% 60%;
+		--primary-custom-foreground: 0 0% 100%;
 		
+
 		--background: 240 100% 98%;
 		--foreground: 0 0% 0%;       
 	  
@@ -20,8 +23,6 @@
 		--primary: 247 92% 60%;
 		--primary-foreground: 0 0% 0%;
 	  
-		--primary-custom: 247 92% 60%;
-		--primary-custom-foreground: 0 0% 100%;
 	  
 		--secondary: 235 32% 92%;
 		--secondary-foreground: 0 0% 0%;
@@ -55,9 +56,6 @@
 
 		--primary: 0 0% 98%;
 		--primary-foreground: 0 0% 100%;
-
-		--primary-custom: 247 92% 60%;
-		--primary-custom-foreground: 0 0% 100%;
 
 		--secondary: 240 3.7% 15.9%;
 		--secondary-foreground: 0 0% 98%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,28 +6,28 @@
 	:root {
 		--background: 0 0% 100%;
 		--foreground: 240 10% 3.9%;
-
+	  
 		--card: 0 0% 100%;
 		--card-foreground: 240 10% 3.9%;
-
+	  
 		--popover: 0 0% 100%;
 		--popover-foreground: 240 10% 3.9%;
 
 		--primary: 240 5.9% 10%;
 		--primary-foreground: 0 0% 100%;
-
+	  
 		--secondary: 240 4.8% 95.9%;
 		--secondary-foreground: 240 5.9% 10%;
-
+	  
 		--muted: 240 4.8% 95.9%;
 		--muted-foreground: 240 3.8% 46.1%;
-
+	  
 		--accent: 240 4.8% 95.9%;
 		--accent-foreground: 240 5.9% 10%;
-
+	  
 		--destructive: 0 84.2% 60.2%;
 		--destructive-foreground: 0 0% 98%;
-
+	  
 		--border: 240 5.9% 90%;
 		--input: 240 5.9% 90%;
 		--icon: 217 19% 27%;
@@ -78,37 +78,37 @@
 		--link: 220 100% 66%;
 	}
 	.light {
-		--background: 240 10% 3.9%;
-		--foreground: 0 0% 98%;
-
+		--background: 240 100% 100%;  
+		--foreground: 0 0% 0%;       
+	  
 		--card: 240 10% 3.9%;
 		--card-foreground: 0 0% 98%;
-
+	  
 		--popover: 240 10% 3.9%;
 		--popover-foreground: 0 0% 98%;
-
+	  
 		--primary: 0 0% 98%;
 		--primary-foreground: 0 0% 100%;
-
+	  
 		--primary-custom: 247 92% 60%;
 		--primary-custom-foreground: 0 0% 100%;
-
+	  
 		--secondary: 240 3.7% 15.9%;
 		--secondary-foreground: 0 0% 98%;
-
+	  
 		--muted: 240 3.7% 15.9%;
 		--muted-foreground: 240 5% 64.9%;
-
+	  
 		--accent: 240 3.7% 15.9%;
 		--accent-foreground: 0 0% 98%;
-
+	  
 		--destructive: 0 62.8% 30.6%;
 		--destructive-foreground: 0 0% 98%;
-
+	  
 		--border: 240 3.7% 15.9%;
 		--input: 240 3.7% 15.9%;
 		--ring: 240 4.9% 83.9%;
-
+	  
 		--link: 220 100% 66%;
 	}
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -99,8 +99,8 @@
 		--muted: 235 32% 92%;
 		--muted-foreground: 240 5% 5%;
 	  
-		--accent: 240 3.7% 15.9%;
-		--accent-foreground: 0 0% 98%;
+		--accent: 235 32% 92%;
+		--accent-foreground: 0 0% 0%;
 	  
 		--destructive: 0 62.8% 30.6%;
 		--destructive-foreground: 0 0% 98%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,28 +17,29 @@
 		--border: 240 3.7% 15.9%;
 		--input: 240 3.7% 15.9%;
 		--ring: 240 4.9% 83.9%;
-		--link: 220 100% 66%;
-
+		
 		--background: 240 100% 98%;
 		--foreground: 0 0% 0%;       
-	  
+		
 		--card: 240 100% 98%;
 		--card-foreground: 0 0% 0%;
-	  
+		
 		--popover: 240 100% 98%;
 		--popover-foreground: 0 0% 0%;
-	  
+		
 		--primary: 247 92% 60%;
 		--primary-foreground: 0 0% 100%;
-	  
+		
 		--secondary: 235 32% 92%;
 		--secondary-foreground: 0 0% 0%;
-	  
+		
 		--muted: 235 32% 92%;
 		--muted-foreground: 240 50% 20%;
-	  
+		
 		--accent: 235 32% 92%;
 		--accent-foreground: 0 0% 0%;
+
+		--link: 211 100% 50%;
 	}
 
 	.dark {
@@ -62,6 +63,8 @@
 
 		--accent: 240 3.7% 15.9%;
 		--accent-foreground: 0 0% 98%;
+
+		--link: 220 100% 66%;
 	}
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -77,6 +77,40 @@
 
 		--link: 220 100% 66%;
 	}
+	.light {
+		--background: 240 10% 3.9%;
+		--foreground: 0 0% 98%;
+
+		--card: 240 10% 3.9%;
+		--card-foreground: 0 0% 98%;
+
+		--popover: 240 10% 3.9%;
+		--popover-foreground: 0 0% 98%;
+
+		--primary: 0 0% 98%;
+		--primary-foreground: 0 0% 100%;
+
+		--primary-custom: 247 92% 60%;
+		--primary-custom-foreground: 0 0% 100%;
+
+		--secondary: 240 3.7% 15.9%;
+		--secondary-foreground: 0 0% 98%;
+
+		--muted: 240 3.7% 15.9%;
+		--muted-foreground: 240 5% 64.9%;
+
+		--accent: 240 3.7% 15.9%;
+		--accent-foreground: 0 0% 98%;
+
+		--destructive: 0 62.8% 30.6%;
+		--destructive-foreground: 0 0% 98%;
+
+		--border: 240 3.7% 15.9%;
+		--input: 240 3.7% 15.9%;
+		--ring: 240 4.9% 83.9%;
+
+		--link: 220 100% 66%;
+	}
 }
 
 @media (prefers-color-scheme: "dark") {

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,42 +4,41 @@
 
 @layer base {
 	:root {
-		--background: 0 0% 100%;
-		--foreground: 240 10% 3.9%;
+		--background: 240 100% 98%;
+		--foreground: 0 0% 0%;       
 	  
-		--card: 0 0% 100%;
-		--card-foreground: 240 10% 3.9%;
+		--card: 240 100% 98%;
+		--card-foreground: 0 0% 0%;
 	  
-		--popover: 0 0% 100%;
-		--popover-foreground: 240 10% 3.9%;
-
-		--primary: 240 5.9% 10%;
-		--primary-foreground: 0 0% 100%;
+		--popover: 240 100% 98%;
+		--popover-foreground: 0 0% 0%;
 	  
-		--secondary: 240 4.8% 95.9%;
-		--secondary-foreground: 240 5.9% 10%;
+		--primary: 247 92% 60%;
+		--primary-foreground: 0 0% 0%;
 	  
-		--muted: 240 4.8% 95.9%;
-		--muted-foreground: 240 3.8% 46.1%;
-	  
-		--accent: 240 4.8% 95.9%;
-		--accent-foreground: 240 5.9% 10%;
-	  
-		--destructive: 0 84.2% 60.2%;
-		--destructive-foreground: 0 0% 98%;
-	  
-		--border: 240 5.9% 90%;
-		--input: 240 5.9% 90%;
-		--icon: 217 19% 27%;
-		--ring: 240 10% 3.9%;
-
-		--radius: 0.5rem;
-
 		--primary-custom: 247 92% 60%;
 		--primary-custom-foreground: 0 0% 100%;
-
+	  
+		--secondary: 235 32% 92%;
+		--secondary-foreground: 0 0% 0%;
+	  
+		--muted: 235 32% 92%;
+		--muted-foreground: 240 50% 20%;
+	  
+		--accent: 235 32% 92%;
+		--accent-foreground: 0 0% 0%;
+	  
+		--destructive: 0 62.8% 30.6%;
+		--destructive-foreground: 0 0% 98%;
+	  
+		--border: 240 3.7% 15.9%;
+		--input: 240 3.7% 15.9%;
+		--ring: 240 4.9% 83.9%;
+	  
 		--link: 220 100% 66%;
-
+		
+		--icon: 217 19% 27%;
+		--radius: 0.5rem;
 		--transparent: rgba(255, 255, 255, 0);
 	}
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -97,7 +97,7 @@
 		--secondary-foreground: 0 0% 0%;
 	  
 		--muted: 235 32% 92%;
-		--muted-foreground: 240 5% 5%;
+		--muted-foreground: 240 50% 20%;
 	  
 		--accent: 235 32% 92%;
 		--accent-foreground: 0 0% 0%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,10 @@
 
 @layer base {
 	:root {
+		--icon: 217 19% 27%;
+		--radius: 0.5rem;
+		--transparent: rgba(255, 255, 255, 0);
+		
 		--background: 240 100% 98%;
 		--foreground: 0 0% 0%;       
 	  
@@ -37,9 +41,6 @@
 	  
 		--link: 220 100% 66%;
 		
-		--icon: 217 19% 27%;
-		--radius: 0.5rem;
-		--transparent: rgba(255, 255, 255, 0);
 	}
 
 	.dark {

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,9 +7,17 @@
 		--icon: 217 19% 27%;
 		--radius: 0.5rem;
 		--transparent: rgba(255, 255, 255, 0);
+
 		--primary-custom: 247 92% 60%;
 		--primary-custom-foreground: 0 0% 100%;
 		
+		--destructive: 0 62.8% 30.6%;
+		--destructive-foreground: 0 0% 98%;
+	  
+		--border: 240 3.7% 15.9%;
+		--input: 240 3.7% 15.9%;
+		--ring: 240 4.9% 83.9%;
+		--link: 220 100% 66%;
 
 		--background: 240 100% 98%;
 		--foreground: 0 0% 0%;       
@@ -23,7 +31,6 @@
 		--primary: 247 92% 60%;
 		--primary-foreground: 0 0% 0%;
 	  
-	  
 		--secondary: 235 32% 92%;
 		--secondary-foreground: 0 0% 0%;
 	  
@@ -32,16 +39,6 @@
 	  
 		--accent: 235 32% 92%;
 		--accent-foreground: 0 0% 0%;
-	  
-		--destructive: 0 62.8% 30.6%;
-		--destructive-foreground: 0 0% 98%;
-	  
-		--border: 240 3.7% 15.9%;
-		--input: 240 3.7% 15.9%;
-		--ring: 240 4.9% 83.9%;
-	  
-		--link: 220 100% 66%;
-		
 	}
 
 	.dark {
@@ -65,15 +62,6 @@
 
 		--accent: 240 3.7% 15.9%;
 		--accent-foreground: 0 0% 98%;
-
-		--destructive: 0 62.8% 30.6%;
-		--destructive-foreground: 0 0% 98%;
-
-		--border: 240 3.7% 15.9%;
-		--input: 240 3.7% 15.9%;
-		--ring: 240 4.9% 83.9%;
-
-		--link: 220 100% 66%;
 	}
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -29,7 +29,7 @@
 		--popover-foreground: 0 0% 0%;
 	  
 		--primary: 247 92% 60%;
-		--primary-foreground: 0 0% 0%;
+		--primary-foreground: 0 0% 100%;
 	  
 		--secondary: 235 32% 92%;
 		--secondary-foreground: 0 0% 0%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -87,7 +87,7 @@
 		--popover: 240 100% 98%;
 		--popover-foreground: 0 0% 0%;
 	  
-		--primary: 0 0% 0%;
+		--primary: 247 92% 60%;
 		--primary-foreground: 0 0% 0%;
 	  
 		--primary-custom: 247 92% 60%;

--- a/app/globals.css
+++ b/app/globals.css
@@ -153,6 +153,9 @@
 }
 
 @layer base {
+	:root{
+		@apply dark:dark light;
+	}
 	html {
 		scroll-behavior: smooth;
 	}

--- a/app/globals.css
+++ b/app/globals.css
@@ -113,45 +113,6 @@
 	}
 }
 
-@media (prefers-color-scheme: "dark") {
-	@layer base {
-		:root {
-			--background: 240 10% 3.9%;
-			--foreground: 0 0% 98%;
-
-			--card: 240 10% 3.9%;
-			--card-foreground: 0 0% 98%;
-
-			--popover: 240 10% 3.9%;
-			--popover-foreground: 0 0% 98%;
-
-			--primary: 0 0% 98%;
-			--primary-foreground: 0 0% 100%;
-
-			--primary-custom: 247 92% 60%;
-			--primary-custom-foreground: 0 0% 100%;
-
-			--secondary: 240 3.7% 15.9%;
-			--secondary-foreground: 0 0% 98%;
-
-			--muted: 220 20% 7%;
-			--muted-foreground: 240 5% 64.9%;
-
-			--accent: 240 3.7% 15.9%;
-			--accent-foreground: 0 0% 98%;
-
-			--destructive: 0 62.8% 30.6%;
-			--destructive-foreground: 0 0% 98%;
-
-			--border: 240 3.7% 15.9%;
-			--input: 240 3.7% 15.9%;
-			--ring: 240 4.9% 83.9%;
-
-			--link: 220 100% 66%;
-		}
-	}
-}
-
 @layer base {
 	:root{
 		@apply dark:dark light;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ export default function Home() {
 					Timeloom helps you to document your technical journey in an
 					activity timeline like page. You can create your own page,
 					craft it as you like and show it off to the world.{" "}
-					<span className="dark:text-white font-medium">
+					<span className="dark:text-white text-black font-medium">
 						Claim your username today!
 					</span>
 				</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ export default function Home() {
 					Timeloom helps you to document your technical journey in an
 					activity timeline like page. You can create your own page,
 					craft it as you like and show it off to the world.{" "}
-					<span className="text-white font-medium">
+					<span className="dark:text-white font-medium">
 						Claim your username today!
 					</span>
 				</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,8 +28,8 @@ export default function Home() {
 					src={bgGrid}
 					alt="Background Grid Image"
 					className="opacity-40 absolute top-[35%] left-1/2 -translate-x-1/2 -translate-y-1/2 -z-10 select-none pointer-events-none"
-				/>
-				<h1 className="scroll-m-20 text-4xl font-semibold leading-tight lg:leading-tight lg:text-6xl bg-gradient-to-br from-[#ffffffff] from-[30%] to-[#ffffff80] text-transparent bg-clip-text">
+									/>
+				<h1 className="scroll-m-20 text-4xl font-semibold leading-tight lg:leading-tight lg:text-6xl bg-gradient-to-br from-[#00000080] from-[65%] to-[#2f2f2f00] dark:bg-gradient-to-br dark:from-[#ffffffff] dark:from-[30%] dark:to-[#ffffff80] text-transparent bg-clip-text">
 					Craft your tech journey timeline on{" "}
 					<span className="">Timeloom</span>
 				</h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
 					alt="Background Grid Image"
 					className="opacity-40 absolute top-[35%] left-1/2 -translate-x-1/2 -translate-y-1/2 -z-10 select-none pointer-events-none"
 									/>
-				<h1 className="scroll-m-20 text-4xl font-semibold leading-tight lg:leading-tight lg:text-6xl bg-gradient-to-br from-[#00000080] from-[65%] to-[#2f2f2f00] dark:bg-gradient-to-br dark:from-[#ffffffff] dark:from-[30%] dark:to-[#ffffff80] text-transparent bg-clip-text">
+				<h1 className="scroll-m-20 text-4xl font-semibold leading-tight lg:leading-tight lg:text-6xl bg-gradient-to-br from-[#000000ab] from-[30%] to-[#3d3d3df0] dark:bg-gradient-to-br dark:from-[#ffffffff] dark:from-[30%] dark:to-[#ffffff80] text-transparent bg-clip-text">
 					Craft your tech journey timeline on{" "}
 					<span className="">Timeloom</span>
 				</h1>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,7 +7,7 @@ const Footer = () => {
 				Made with &lt;3 by&nbsp;
 				<Link
 					href="https://bento.me/adarsh"
-					className="hover:underline text-white"
+					className="hover:underline dark:text-white text-black"
 				>
 					Adarsh Dubey
 				</Link>

--- a/components/ui/Tag.tsx
+++ b/components/ui/Tag.tsx
@@ -25,13 +25,13 @@ const Tag = ({ className, type, ...props }: TagProps) => {
 		<span
 			className={`${className} text-sm border block min-w-fit px-[6px] py-[2px] rounded-full transition-shadow ${
 				type == "Founder" &&
-				"bg-tag-purple border-tag-purple-border text-tag-purple-foreground hover:shadow-purple"
+				"bg-tag-purple border-tag-purple-light-border dark:border-tag-purple-border text-tag-purple-light-foreground dark:text-tag-purple-foreground hover:shadow-purple"
 			} ${
 				type == "Dev" &&
-				"bg-tag-green border-tag-green-border text-tag-green-foreground hover:shadow-green"
+				"bg-tag-green border-tag-green-light-border dark:border-tag-green-border text-tag-green-light-foreground dark:text-tag-green-foreground hover:shadow-green"
 			} ${
 				type == "First 100" &&
-				"bg-tag-cyan border-tag-cyan-border text-tag-cyan-foreground hover:shadow-cyan"
+				"bg-tag-cyan border-tag-cyan-light-border dark:border-tag-cyan-border text-tag-cyan-light-foreground dark:text-tag-cyan-foreground hover:shadow-cyan"
 			}`}
 			{...props}
 		>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
 		variants: {
 			variant: {
 				default:
-					"bg-primary-custom hover:text-[#000] text-primary-foreground shadow hover:bg-primary/90 rounded-md",
+					"bg-primary-custom hover:text-[#FFF] dark:hover:text-[#000] text-primary-foreground shadow hover:bg-primary/90 rounded-md",
 				destructive:
 					"bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 rounded-md",
 				outline:

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
 		variants: {
 			variant: {
 				default:
-					"bg-primary-custom hover:text-[#FFF] dark:hover:text-[#000] text-primary-foreground shadow hover:bg-primary/90 rounded-md",
+					"bg-primary-custom hover:text-[#FFF] dark:hover:text-[#000] text-primary-foreground shadow hover:bg-primary/70 dark:hover:bg-primary/90 rounded-md",
 				destructive:
 					"bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 rounded-md",
 				outline:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -82,6 +82,11 @@ module.exports = {
 					foreground: "rgba(162, 238, 239, 1)",
 					border: "rgba(162, 238, 239, .5)",
 				},
+				"tag-green-light": {
+					DEFAULT: "rgba(0, 134, 114, .18)",
+					foreground: "rgba(0, 169, 144, 1)",
+					border: "rgba(0, 169, 144, .5)",
+				},
 				"tag-green": {
 					DEFAULT: "rgba(0, 134, 114, .18)",
 					foreground: "rgba(0, 230, 196, 1)",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -92,6 +92,11 @@ module.exports = {
 					foreground: "rgba(0, 230, 196, 1)",
 					border: "rgba(0, 230, 196, .5)",
 				},
+				"tag-pink-light": {
+					DEFAULT: "rgba(216, 118, 227, .18)",
+					foreground: "rgba(209, 137, 168, 1)",
+					border: "rgba(209, 137, 168, .5)",
+				},
 				"tag-pink": {
 					DEFAULT: "rgba(216, 118, 227, .18)",
 					foreground: "rgba(217, 126, 229, 1)",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-	darkMode: ["class"],
+	darkMode: ["media", "class"],
 	content: [
 		"./pages/**/*.{ts,tsx}",
 		"./components/**/*.{ts,tsx}",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -72,6 +72,11 @@ module.exports = {
 					foreground: "rgba(193, 184, 255, 1)",
 					border: "rgba(193, 184, 255, .5)",
 				},
+				"tag-cyan-light": {
+					DEFAULT: "rgba(162, 238, 239, .18)",
+					foreground: "rgba(22, 128, 136, 1)",
+					border: "rgba(22, 128, 136, .5)",
+				},
 				"tag-cyan": {
 					DEFAULT: "rgba(162, 238, 239, .18)",
 					foreground: "rgba(162, 238, 239, 1)",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -62,6 +62,11 @@ module.exports = {
 					DEFAULT: "hsl(var(--card))",
 					foreground: "hsl(var(--card-foreground))",
 				},
+				"tag-purple-light": {
+					DEFAULT: "rgba(112, 87, 255, .18)",
+					foreground: "rgba(90, 34, 139, 1)",
+					border: "rgba(90, 34, 139, .5)",
+				},
 				"tag-purple": {
 					DEFAULT: "rgba(112, 87, 255, .18)",
 					foreground: "rgba(193, 184, 255, 1)",


### PR DESCRIPTION
This fixes #9 

Changes were tested by running Timeloom using `npm run dev` (`dev` script)

Summary of Changes
---
Modified the following files:

- `app/globals.css`
  - Added light mode styles
  - Modified base layer to apply light/dark mode styles to root based on user system preference
- `app/page.tsx`
  - Added landing page Header text gradient for light mode
  - Wrapped original text gradient styling in `dark:{class}` to apply them in dark mode
  - Added "Claim Username" blurb styling for light mode
  - Wrapped original blurb styling in `dark:{class}` to apply it in dark mode
- `components/Footer.tsx`
  - Added light mode styling for `Link` component in Footer
  - Wrapped original Link component styling inside `dark:{class}` to apply them in dark mode
- `components/ui/button.tsx`
  - Added hover coloring for light mode
  - Wrapped original hover coloring inside `dark:{class}` to apply them in dark mode
- `tailwind.config.ts`
  - extended dark mode settings to use `media` (for OS preference) strategy alongside existing `class` (manual) strategy, as per https://tailwindcss.com/docs/dark-mode
    - I noticed the order matters here
      - `darkMode: ["media", "class"],` enables **both** the `OS preference` strategy and `class` strategy
      - If `darkMode: ["class", "media"],` is used, **only** the `class` strategy is enabled

Prospective Changes (Pending Maintainer approval)
---
`bg-grid.png` for Light Mode
- If a Figma is provided, I will attempt to create a light mode version of `bg-grid.png` and add it to the assets.
- Logic will be used to show respective versions depending on light/dark mode.